### PR TITLE
Gate scans behind enabled flag

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -4,31 +4,77 @@ import { AdapterManager } from "../adapters/manager.js";
 import { paintOverlay, classifyFromThresholds } from "./ui-overlay.js";
 
 let engine, registry, adapter, unsubscribe;
+let settings = { enabled: true };
 
 async function init() {
-  ({ registry } = await loadRegistry());
-  const { markers } = await loadRegistry();
+  const { registry: loadedRegistry, markers } = await loadRegistry();
+  registry = loadedRegistry;
   engine = new ScoringEngine({ registry, markers });
-
   adapter = AdapterManager.choose();
-  runScan();                         // initial
-  unsubscribe = AdapterManager.watch(adapter, runScan); // live updates
-  window.addEventListener("beforeunload", () => unsubscribe && unsubscribe());
+
+  chrome.storage.local.get(["fp_settings"], ({ fp_settings }) => {
+    applySettings(fp_settings);
+  });
+
+  chrome.storage.onChanged.addListener(handleSettingsChange);
+  window.addEventListener("beforeunload", cleanup);
+}
+
+function handleSettingsChange(changes, area) {
+  if (area !== "local" || !changes.fp_settings) return;
+  applySettings(changes.fp_settings.newValue);
+}
+
+function applySettings(fpSettings = {}) {
+  settings = {
+    enabled: fpSettings.enabled ?? true,
+    thresholds: fpSettings.thresholds || registry.thresholds
+  };
+
+  if (!settings.enabled) {
+    stopWatching();
+    teardownOverlay();
+    return;
+  }
+
+  startWatching();
+}
+
+function startWatching() {
+  if (unsubscribe || !adapter) return;
+  runScan();
+  unsubscribe = AdapterManager.watch(adapter, runScan);
+}
+
+function stopWatching() {
+  if (unsubscribe) {
+    unsubscribe();
+    unsubscribe = undefined;
+  }
+}
+
+function cleanup() {
+  stopWatching();
+  chrome.storage.onChanged.removeListener(handleSettingsChange);
 }
 
 function runScan() {
+  if (!settings?.enabled) return;
+
   const msgs = AdapterManager.scan(adapter);
   if (!msgs || msgs.length === 0) return;
 
   const res = engine.score(msgs);
-  chrome.storage.local.get(["fp_settings"], ({ fp_settings }) => {
-    const s = fp_settings || {};
-    const th = s.thresholds || registry.thresholds;
-    const level = classifyFromThresholds(res.S, res.killer, th);
-    paintOverlay(level, res.S, res.hits);
-    const tid = AdapterManager.threadId(adapter) || location.href;
-    chrome.storage.local.set({ ["fp_state_"+tid]: { level, score: res.S, hits: res.hits, t: Date.now() } });
-  });
+  const th = settings.thresholds || registry.thresholds;
+  const level = classifyFromThresholds(res.S, res.killer, th);
+  paintOverlay(level, res.S, res.hits);
+  const tid = AdapterManager.threadId(adapter) || location.href;
+  chrome.storage.local.set({ ["fp_state_"+tid]: { level, score: res.S, hits: res.hits, t: Date.now() } });
+}
+
+function teardownOverlay() {
+  const el = document.getElementById("__fp_overlay");
+  if (el) el.remove();
 }
 
 init();

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -67,7 +67,7 @@ function cleanup() {
 }
 
 function runScan() {
-  if (!settings?.enabled) return;
+  if (!settings.enabled) return;
 
   const msgs = AdapterManager.scan(adapter);
   if (!msgs || msgs.length === 0) return;

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -12,9 +12,17 @@ async function init() {
   engine = new ScoringEngine({ registry, markers });
   adapter = AdapterManager.choose();
 
+  let initialized = false;
   chrome.storage.local.get(["fp_settings"], ({ fp_settings }) => {
+    initialized = true;
     applySettings(fp_settings);
   });
+  // Fallback if storage doesn't respond
+  setTimeout(() => {
+    if (!initialized) {
+      applySettings();
+    }
+  }, 100);
 
   chrome.storage.onChanged.addListener(handleSettingsChange);
   window.addEventListener("beforeunload", cleanup);


### PR DESCRIPTION
## Summary
- load the registry once and reuse the markers when building the scoring engine
- gate runScan and adapter watchers behind the `fp_settings.enabled` flag and listen for storage changes
- tear down the overlay and stop watchers when the feature is disabled so popup toggles take effect immediately

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691c4ed432b083228b4f63bde2926fdb)