### PR TITLE
Add manifest-driven marker loader

### DIFF
--- a/markers/registry.json
+++ b/markers/registry.json
@@ -15,6 +15,18 @@
     ["SEM_PLATFORM_SWITCH_WHATSAPP","ATO_WEBCAM_PHRASE"],
     ["SEM_PLATFORM_SWITCH_WHATSAPP","SEM_MILITARY_OFFSHORE_COVER"],
     ["SEM_INTRODUCE_AGENT_BROKER","SEM_INVESTMENT_PIVOT"]
-  ]
+  ],
+  "marker_sources": {
+    "high": [
+      "ATO_WEBCAM_PHRASE.json",
+      "SEM_INVESTMENT_PIVOT.json",
+      "SEM_PAYMENT_METHOD_REQUEST.json",
+      "SEM_PLATFORM_SWITCH_WHATSAPP.json"
+    ],
+    "medium": [
+      "CLU_AGE_INCONSISTENCY.json"
+    ],
+    "soft": []
+  }
 }
 

--- a/markers/registry.json
+++ b/markers/registry.json
@@ -21,10 +21,26 @@
       "ATO_WEBCAM_PHRASE.json",
       "SEM_INVESTMENT_PIVOT.json",
       "SEM_PAYMENT_METHOD_REQUEST.json",
-      "SEM_PLATFORM_SWITCH_WHATSAPP.json"
+      "SEM_PLATFORM_SWITCH_WHATSAPP.json",
+      "SEM_MT4_MT5_EXCHANGE.json",
+      "SEM_SIGNAL_GROUP_INVITE.json",
+      "SEM_USDT_WALLET_REQUEST.json",
+      "SEM_CUSTOMS_PACKAGE_FEE.json",
+      "SEM_TRAVEL_VISA_EMERGENCY.json",
+      "SEM_MILITARY_OFFSHORE_COVER.json",
+      "SEM_DISAPPEARING_MSG_WHATSAPP.json",
+      "SEM_ID_VERIFICATION_AVOIDANCE.json",
+      "ATO_LOVE_BOMBING.json",
+      "ATO_GUILT_TRIP.json",
+      "ATO_FUTURE_FAKING.json"
     ],
     "medium": [
-      "CLU_AGE_INCONSISTENCY.json"
+      "CLU_AGE_INCONSISTENCY.json",
+      "CLU_ALIAS_NAME_CHANGE.json",
+      "CLU_NAME_VARIATION.json",
+      "SEM_STATUS_GRANDIOSE.json",
+      "SEM_QUESTION_DEFLECTION.json",
+      "SEM_PASSIVE_INCOME_FRAME.json"
     ],
     "soft": []
   }

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -6,9 +6,9 @@ import { paintOverlay, classifyFromThresholds } from "./ui-overlay.js";
 let engine, registry, adapter, unsubscribe;
 
 async function init() {
-  ({ registry } = await loadRegistry());
-  const { markers } = await loadRegistry();
-  engine = new ScoringEngine({ registry, markers });
+  const payload = await loadRegistry();
+  registry = payload.registry;
+  engine = new ScoringEngine(payload);
 
   adapter = AdapterManager.choose();
   runScan();                         // initial

--- a/src/engine/rules.js
+++ b/src/engine/rules.js
@@ -9,12 +9,24 @@ async function fetchJson(url) {
 }
 
 function manifestEntries(registry) {
-  const manifest =
-    registry.marker_sources ||
-    registry.markerSources ||
-    registry.markerManifest ||
-    registry.markers;
-
+  const propertyNames = [
+    "marker_sources",
+    "markerSources",
+    "markerManifest",
+    "markers"
+  ];
+  let manifest;
+  let usedProperty;
+  for (const name of propertyNames) {
+    if (registry[name]) {
+      manifest = registry[name];
+      usedProperty = name;
+      break;
+    }
+  }
+  if (usedProperty) {
+    console.debug(`[RoFratect] Using manifest property "${usedProperty}" from registry.`);
+  }
   if (!manifest || typeof manifest !== "object") return [];
   return Object.entries(manifest);
 }

--- a/src/engine/rules.js
+++ b/src/engine/rules.js
@@ -1,36 +1,65 @@
-export async function loadRegistry() {
-  const reg = await fetch(chrome.runtime.getURL("markers/registry.json")).then(r => r.json());
-  const glob = [];
-  for (const tier of ["high","medium","soft"]) {
-    const dir = `markers/${tier}/`;
-    const files = [
-      // statisch gelistete Files, ergänze alle die du nutzt
-      "SEM_PAYMENT_METHOD_REQUEST.json",
-      "SEM_INVESTMENT_PIVOT.json",
-      "SEM_CUSTOMS_PACKAGE_FEE.json",
-      "SEM_TRAVEL_VISA_EMERGENCY.json",
-      "SEM_PLATFORM_SWITCH_WHATSAPP.json",
-      "SEM_MT4_MT5_EXCHANGE.json",
-      "SEM_SIGNAL_GROUP_INVITE.json",
-      "SEM_USDT_WALLET_REQUEST.json",
-      "ATO_WEBCAM_PHRASE.json",
-      "SEM_MILITARY_OFFSHORE_COVER.json",
-      "SEM_DISAPPEARING_MSG_WHATSAPP.json",
-      "CLU_ALIAS_NAME_CHANGE.json",
-      "CLU_NAME_VARIATION.json",
-      "CLU_AGE_INCONSISTENCY.json",
-      "SEM_STATUS_GRANDIOSE.json",
-      "SEM_QUESTION_DEFLECTION.json",
-      "SEM_PASSIVE_INCOME_FRAME.json",
-      "SEM_ID_VERIFICATION_AVOIDANCE.json",
-      "ATO_LOVE_BOMBING.json",
-      "ATO_GUILT_TRIP.json",
-      "ATO_FUTURE_FAKING.json"
-    ];
-    for (const f of files) {
-      try { glob.push(await fetch(chrome.runtime.getURL(dir + f)).then(r => r.json())); } catch {}
-    }
+let loadPromise;
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status}`);
   }
-  return { registry: reg, markers: glob };
+  return response.json();
 }
 
+function manifestEntries(registry) {
+  const manifest =
+    registry.marker_sources ||
+    registry.markerSources ||
+    registry.markerManifest ||
+    registry.markers;
+
+  if (!manifest || typeof manifest !== "object") return [];
+  return Object.entries(manifest);
+}
+
+export function loadRegistry() {
+  if (!loadPromise) {
+    loadPromise = (async () => {
+      const registryUrl = chrome.runtime.getURL("markers/registry.json");
+      const registry = await fetchJson(registryUrl);
+      const entries = manifestEntries(registry);
+
+      if (entries.length === 0) {
+        console.warn(
+          "[RoFratect] No marker manifest declared in markers/registry.json; no marker rules will be loaded."
+        );
+      }
+
+      const failures = [];
+      const markerPromises = entries.flatMap(([tier, files = []]) =>
+        (files || []).map(async file => {
+          const path = `markers/${tier}/${file}`;
+          const url = chrome.runtime.getURL(path);
+          try {
+            return await fetchJson(url);
+          } catch (error) {
+            failures.push({ path, error });
+            return null;
+          }
+        })
+      );
+
+      const markers = (await Promise.all(markerPromises)).filter(Boolean);
+
+      if (failures.length > 0) {
+        console.warn(
+          `[RoFratect] Failed to load ${failures.length} marker(s): ${failures
+            .map(({ path }) => path)
+            .join(", ")}`,
+          failures
+        );
+      }
+
+      return { registry, markers };
+    })();
+  }
+
+  return loadPromise;
+}


### PR DESCRIPTION
## Summary
- list marker files in `markers/registry.json` so the runtime loader no longer needs a hard-coded array
- refactor `loadRegistry` to read the manifest, cache the results, and surface any marker load failures
- update the content script to reuse the cached registry payload when constructing the scoring engine

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691c4ee2affc83229797c12e1e1c6a83)